### PR TITLE
feat(#13): quick-capture brain dump from any page

### DIFF
--- a/src/app/client-shell.tsx
+++ b/src/app/client-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CmdKSearch } from "@/components/layout/cmd-k-search";
+import { QuickCapture } from "@/components/layout/quick-capture";
 import { MovieChat } from "@/components/chat/movie-chat";
 import { Sidebar } from "@/components/layout/sidebar";
 import { BottomNav } from "@/components/layout/bottom-nav";
@@ -13,6 +14,7 @@ import { ArrowUp } from "lucide-react";
 
 export function ClientShell({ children }: { children: React.ReactNode }) {
   const [cmdKOpen, setCmdKOpen] = useState(false);
+  const [quickCaptureOpen, setQuickCaptureOpen] = useState(false);
   const [showScrollTop, setShowScrollTop] = useState(false);
   const mainRef = useRef<HTMLElement>(null);
   const pathname = usePathname();
@@ -24,6 +26,10 @@ export function ClientShell({ children }: { children: React.ReactNode }) {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setCmdKOpen((o) => !o);
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "n") {
+        e.preventDefault();
+        setQuickCaptureOpen((o) => !o);
       }
     }
     window.addEventListener("keydown", handleKey);
@@ -64,15 +70,16 @@ export function ClientShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen overflow-hidden">
       <AppProgressBar height="2px" color="hsl(263,90%,65%)" options={{ showSpinner: false }} shallowRouting />
-      <Sidebar onCmdK={() => setCmdKOpen(true)} />
+      <Sidebar onCmdK={() => setCmdKOpen(true)} onQuickCapture={() => setQuickCaptureOpen(true)} />
       <div className="flex-1 flex flex-col min-w-0">
-        <MobileHeader onCmdK={() => setCmdKOpen(true)} />
+        <MobileHeader onCmdK={() => setCmdKOpen(true)} onQuickCapture={() => setQuickCaptureOpen(true)} />
         <main ref={mainRef} className="flex-1 overflow-y-auto pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
           {children}
         </main>
       </div>
       <BottomNav />
       <CmdKSearch open={cmdKOpen} onClose={() => setCmdKOpen(false)} />
+      <QuickCapture open={quickCaptureOpen} onClose={() => setQuickCaptureOpen(false)} />
       {isWatchList && <MovieChat />}
       <button
         onClick={() => mainRef.current?.scrollTo({ top: 0, behavior: "smooth" })}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { UserButton } from "@clerk/nextjs";
-import { Brain, Command } from "lucide-react";
+import { Brain, Command, Plus } from "lucide-react";
 
 interface MobileHeaderProps {
   onCmdK: () => void;
+  onQuickCapture: () => void;
 }
 
-export function MobileHeader({ onCmdK }: MobileHeaderProps) {
+export function MobileHeader({ onCmdK, onQuickCapture }: MobileHeaderProps) {
   return (
     <header className="lg:hidden flex items-center justify-between px-3 h-9 border-b border-[hsl(0_0%_22%)] bg-[hsl(0_0%_5%)] shrink-0">
       <div className="flex items-center gap-1.5 min-w-0">
@@ -17,6 +18,13 @@ export function MobileHeader({ onCmdK }: MobileHeaderProps) {
         <span className="text-xs font-semibold text-white truncate">Mergen</span>
       </div>
       <div className="flex items-center gap-1">
+        <button
+          onClick={onQuickCapture}
+          className="p-1.5 rounded-md text-[hsl(0_0%_68%)] hover:text-white hover:bg-[hsl(0_0%_13%)] transition-colors min-h-[36px] min-w-[36px] flex items-center justify-center"
+          title="Quick capture"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
         <button
           onClick={onCmdK}
           className="p-1.5 rounded-md text-[hsl(0_0%_68%)] hover:text-white hover:bg-[hsl(0_0%_13%)] transition-colors min-h-[36px] min-w-[36px] flex items-center justify-center"

--- a/src/components/layout/quick-capture.tsx
+++ b/src/components/layout/quick-capture.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { api } from "../../../convex/_generated/api";
+import { useMutation } from "convex/react";
+import { Brain, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+interface QuickCaptureProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function QuickCapture({ open, onClose }: QuickCaptureProps) {
+  const [content, setContent] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const save = useMutation(api.brainDumps.save);
+
+  useEffect(() => {
+    if (open) {
+      setContent("");
+      setTimeout(() => textareaRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  function handleSave() {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    startTransition(async () => {
+      await save({ content: trimmed });
+      toast.success("Brain dump captured");
+      onClose();
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      onClose();
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+      <div
+        className="relative w-full max-w-xl rounded-xl border border-[hsl(0_0%_28%)] bg-[hsl(0_0%_10%)] shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[hsl(0_0%_22%)]">
+          <Brain className="w-4 h-4 text-[hsl(0_0%_68%)] shrink-0" />
+          <span className="text-sm text-[hsl(0_0%_68%)]">Quick capture</span>
+          <div className="ml-auto flex items-center gap-1">
+            <kbd className="text-[10px] bg-[hsl(0_0%_12%)] border border-[hsl(0_0%_28%)] rounded px-1.5 py-0.5 text-[hsl(0_0%_68%)]">⌘↵</kbd>
+            <span className="text-[10px] text-[hsl(0_0%_50%)]">save</span>
+          </div>
+        </div>
+        <div className="p-3">
+          <textarea
+            ref={textareaRef}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Capture a thought…"
+            rows={5}
+            className="w-full bg-transparent text-sm text-white placeholder:text-[hsl(0_0%_40%)] outline-none resize-none leading-relaxed"
+          />
+        </div>
+        <div className="flex items-center justify-between px-3 pb-3 pt-0">
+          <span className="text-[11px] text-[hsl(0_0%_40%)]">Goes to Brain Dump for later AI processing</span>
+          <button
+            onClick={handleSave}
+            disabled={!content.trim() || isPending}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-[hsl(263_90%_65%)] hover:bg-[hsl(263_90%_58%)] disabled:opacity-40 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors"
+          >
+            {isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Layers,
   ListTodo,
   PlaySquare,
+  Plus,
   Target,
 } from "lucide-react";
 import Link from "next/link";
@@ -31,9 +32,10 @@ const NAV_ITEMS = [
 
 interface SidebarProps {
   onCmdK: () => void;
+  onQuickCapture: () => void;
 }
 
-export function Sidebar({ onCmdK }: SidebarProps) {
+export function Sidebar({ onCmdK, onQuickCapture }: SidebarProps) {
   const pathname = usePathname();
   const { isAuthenticated } = useConvexAuth();
   const skip = !isAuthenticated;
@@ -96,6 +98,16 @@ export function Sidebar({ onCmdK }: SidebarProps) {
       </nav>
 
       <div className="p-2 border-t border-[hsl(0_0%_22%)] space-y-0.5">
+        <button
+          onClick={onQuickCapture}
+          className="w-full flex items-center gap-3 px-2 lg:px-3 py-2 rounded-md text-sm text-[hsl(0_0%_68%)] hover:text-[hsl(0_0%_80%)] hover:bg-[hsl(0_0%_13%)] transition-colors"
+        >
+          <Plus className="w-4 h-4 shrink-0" />
+          <span className="hidden lg:flex items-center gap-2 flex-1 justify-between">
+            <span>Quick capture</span>
+            <kbd className="text-[10px] bg-[hsl(0_0%_12%)] border border-[hsl(0_0%_28%)] rounded px-1 py-0.5">⌘⇧N</kbd>
+          </span>
+        </button>
         <button
           onClick={onCmdK}
           className="w-full flex items-center gap-3 px-2 lg:px-3 py-2 rounded-md text-sm text-[hsl(0_0%_68%)] hover:text-[hsl(0_0%_80%)] hover:bg-[hsl(0_0%_13%)] transition-colors"


### PR DESCRIPTION
## Summary
- New `QuickCapture` modal component matching the Cmd+K style
- Triggered by ⌘⇧N keyboard shortcut from anywhere
- "Quick capture" button added to sidebar (desktop) with shortcut hint
- "+" button added to mobile header for touch access
- ⌘↵ to save, Esc to dismiss, success toast on save
- Saves directly to Brain Dump for later AI processing

Closes #13

## Test plan
- [ ] Press ⌘⇧N — quick capture modal opens, textarea focused
- [ ] Click "Quick capture" in sidebar — same modal opens
- [ ] Click "+" in mobile header — same modal opens
- [ ] Type a thought, click Save / press ⌘↵ — modal closes, toast shown, entry appears in Brain Dump
- [ ] Press Esc — modal closes without saving
- [ ] Click backdrop — modal closes without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)